### PR TITLE
[修正] GPS軌跡記録の不具合と長時間記録時の電池消費を改善

### DIFF
--- a/src/__tests__/backgroundGeolocationHeadlessTask.test.ts
+++ b/src/__tests__/backgroundGeolocationHeadlessTask.test.ts
@@ -1,0 +1,157 @@
+import BackgroundGeolocation from 'react-native-background-geolocation';
+import { trackLogMMKV } from '../utils/mmkvStorage';
+import { checkAndStoreLocations, resetTrackLogCache, flushTrackLog } from '../utils/Location';
+
+jest.mock('react-native-background-geolocation', () => {
+  const mock = {
+    registerHeadlessTask: jest.fn(),
+    getState: jest.fn(),
+    changePace: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    default: mock,
+    ...mock,
+  };
+});
+
+jest.mock('../utils/mmkvStorage', () => ({
+  trackLogMMKV: {
+    setCurrentLocation: jest.fn(),
+    getTrackingState: jest.fn(() => 'off'),
+    getGpsState: jest.fn(() => 'off'),
+  },
+}));
+
+jest.mock('../utils/Location', () => ({
+  checkAndStoreLocations: jest.fn(),
+  resetTrackLogCache: jest.fn(),
+  flushTrackLog: jest.fn(),
+  toLocationObject: jest.fn((location: any) => ({
+    coords: { ...location.coords },
+    timestamp: location.timestamp,
+  })),
+}));
+
+// モジュールの読み込みでregisterHeadlessTaskが呼ばれ、タスク関数が登録される
+import '../backgroundGeolocationHeadlessTask';
+
+const mockBackgroundGeolocation = BackgroundGeolocation as any;
+const headlessTask: (event: any) => Promise<void> = mockBackgroundGeolocation.registerHeadlessTask.mock.calls[0][0];
+
+const locationEvent = {
+  name: 'location',
+  params: {
+    coords: { latitude: 35.0, longitude: 135.0, altitude: 10, accuracy: 5, heading: 0, speed: 1 },
+    timestamp: 1700000000000,
+  },
+};
+
+describe('backgroundGeolocationHeadlessTask', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (trackLogMMKV.getTrackingState as jest.Mock).mockReturnValue('off');
+    (trackLogMMKV.getGpsState as jest.Mock).mockReturnValue('off');
+    mockBackgroundGeolocation.getState.mockResolvedValue({ enabled: true });
+  });
+
+  it('タスク関数が登録されている', () => {
+    // registerHeadlessTaskの呼び出し自体はモジュール読み込み時（beforeEachのclearAllMocksより前）
+    expect(typeof headlessTask).toBe('function');
+  });
+
+  describe('boot/terminateイベント（記録再開）', () => {
+    it('bootイベント: トラッキング中かつサービス有効ならchangePace(true)で移動モードへ戻す', async () => {
+      (trackLogMMKV.getTrackingState as jest.Mock).mockReturnValue('on');
+
+      await headlessTask({ name: 'boot' });
+
+      expect(mockBackgroundGeolocation.changePace).toHaveBeenCalledWith(true);
+    });
+
+    it('terminateイベント: トラッキング中かつサービス有効ならchangePace(true)を呼ぶ', async () => {
+      (trackLogMMKV.getTrackingState as jest.Mock).mockReturnValue('on');
+
+      await headlessTask({ name: 'terminate' });
+
+      expect(mockBackgroundGeolocation.changePace).toHaveBeenCalledWith(true);
+    });
+
+    it('bootイベント: GPSのみON（トラッキングOFF）でもchangePace(true)を呼ぶ', async () => {
+      (trackLogMMKV.getGpsState as jest.Mock).mockReturnValue('follow');
+
+      await headlessTask({ name: 'boot' });
+
+      expect(mockBackgroundGeolocation.changePace).toHaveBeenCalledWith(true);
+    });
+
+    it('bootイベント: トラッキングOFFかつGPS OFFなら何もしない', async () => {
+      await headlessTask({ name: 'boot' });
+
+      expect(mockBackgroundGeolocation.getState).not.toHaveBeenCalled();
+      expect(mockBackgroundGeolocation.changePace).not.toHaveBeenCalled();
+    });
+
+    it('bootイベント: サービス無効（enabled:false）ならchangePaceを呼ばない', async () => {
+      (trackLogMMKV.getTrackingState as jest.Mock).mockReturnValue('on');
+      mockBackgroundGeolocation.getState.mockResolvedValue({ enabled: false });
+
+      await headlessTask({ name: 'boot' });
+
+      expect(mockBackgroundGeolocation.changePace).not.toHaveBeenCalled();
+    });
+
+    it('bootイベント: changePaceが例外を投げてもタスクは失敗しない', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      (trackLogMMKV.getTrackingState as jest.Mock).mockReturnValue('on');
+      mockBackgroundGeolocation.changePace.mockRejectedValue(new Error('native error'));
+
+      await expect(headlessTask({ name: 'boot' })).resolves.toBeUndefined();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('locationイベント（既存挙動の回帰）', () => {
+    it('現在地は常にMMKVへ保存される', async () => {
+      await headlessTask(locationEvent);
+
+      expect(trackLogMMKV.setCurrentLocation).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: 35.0, longitude: 135.0, timestamp: 1700000000000 })
+      );
+    });
+
+    it('トラッキング中はキャッシュ破棄→保存→flushのread-modify-writeを行う', async () => {
+      (trackLogMMKV.getTrackingState as jest.Mock).mockReturnValue('on');
+
+      await headlessTask(locationEvent);
+
+      expect(resetTrackLogCache).toHaveBeenCalled();
+      expect(checkAndStoreLocations).toHaveBeenCalled();
+      expect(flushTrackLog).toHaveBeenCalled();
+    });
+
+    it('トラッキングOFFなら軌跡は保存しない', async () => {
+      await headlessTask(locationEvent);
+
+      expect(checkAndStoreLocations).not.toHaveBeenCalled();
+    });
+
+    it('locationイベントではchangePaceを呼ばない', async () => {
+      (trackLogMMKV.getTrackingState as jest.Mock).mockReturnValue('on');
+
+      await headlessTask(locationEvent);
+
+      expect(mockBackgroundGeolocation.changePace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('その他のイベント', () => {
+    it('未対応イベントは何もしない', async () => {
+      await headlessTask({ name: 'heartbeat' });
+
+      expect(trackLogMMKV.setCurrentLocation).not.toHaveBeenCalled();
+      expect(mockBackgroundGeolocation.changePace).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/backgroundGeolocationHeadlessTask.ts
+++ b/src/backgroundGeolocationHeadlessTask.ts
@@ -3,6 +3,22 @@ import { checkAndStoreLocations, toLocationObject, resetTrackLogCache, flushTrac
 import { trackLogMMKV } from './utils/mmkvStorage';
 
 BackgroundGeolocation.registerHeadlessTask(async (event) => {
+  // 端末再起動(boot)・タスクキル(terminate)後はプラグインがstationary状態で開始されることがあり、
+  // disableMotionActivityUpdates:trueではmoving復帰が不確実なため、明示的に移動モードへ戻して記録を継続する。
+  if (event.name === 'boot' || event.name === 'terminate') {
+    try {
+      if (trackLogMMKV.getTrackingState() === 'on' || trackLogMMKV.getGpsState() !== 'off') {
+        const state = await BackgroundGeolocation.getState();
+        if (state.enabled) {
+          await BackgroundGeolocation.changePace(true);
+        }
+      }
+    } catch (error) {
+      console.error('[tracking][headless] failed to resume moving state', error);
+    }
+    return;
+  }
+
   if (event.name !== 'location') return;
   try {
     const normalized = toLocationObject(event.params);

--- a/src/backgroundGeolocationHeadlessTask.ts
+++ b/src/backgroundGeolocationHeadlessTask.ts
@@ -1,5 +1,5 @@
 import BackgroundGeolocation from 'react-native-background-geolocation';
-import { checkAndStoreLocations, toLocationObject } from './utils/Location';
+import { checkAndStoreLocations, toLocationObject, resetTrackLogCache, flushTrackLog } from './utils/Location';
 import { trackLogMMKV } from './utils/mmkvStorage';
 
 BackgroundGeolocation.registerHeadlessTask(async (event) => {
@@ -13,7 +13,11 @@ BackgroundGeolocation.registerHeadlessTask(async (event) => {
 
     // トラッキング中だけ軌跡を保存（GPSのみONの場合はスキップ）
     if (trackLogMMKV.getTrackingState() === 'on') {
+      // headlessはメインとは別のJSコンテキスト。Location.tsのメモリ内キャッシュは共有されないため、
+      // タスク先頭でキャッシュを破棄してMMKVから読み込み、末尾で必ずMMKVへ書き戻す（毎回read-modify-write）。
+      resetTrackLogCache();
       checkAndStoreLocations([normalized]);
+      flushTrackLog();
     }
   } catch (error) {
     console.error('[tracking][headless] failed to persist location', error);

--- a/src/components/organisms/CurrentTrackLog.tsx
+++ b/src/components/organisms/CurrentTrackLog.tsx
@@ -30,17 +30,17 @@ const arePropsEqual = (prevProps: Props, nextProps: Props) => {
 export const CurrentTrackLog = React.memo((props: Props) => {
   // props.currentLocationとtotalPointsは再レンダリングのトリガーとして使用（arePropsEqualで比較）
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { currentLocation, totalPoints } = props;
 
-  // 実際のデータはMMKVから直接取得
-  const currentChunk = getDisplayBufferSimplified(400);
-
-  // セグメントをメモ化（精度に基づいて分割）
+  // 実際のデータはメモリ内キャッシュ（無ければMMKV）から取得。
+  // 毎レンダリングでの再取得/再簡略化を避けるため、再描画トリガー（点数・現在地）をキーにメモ化する。
   const segments = useMemo(() => {
+    const currentChunk = getDisplayBufferSimplified(400);
     if (!currentChunk || currentChunk.length === 0) return [];
     return splitTrackByAccuracy(currentChunk);
-  }, [currentChunk]);
+    // currentLocationの緯度経度を依存に含めることで、新しい点が来たときのみ再計算する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [totalPoints, currentLocation?.latitude, currentLocation?.longitude]);
 
   // データがない場合は何も表示しない
   if (segments.length === 0) {

--- a/src/components/organisms/HomeCurrentMarker.tsx
+++ b/src/components/organisms/HomeCurrentMarker.tsx
@@ -10,7 +10,25 @@ interface Props {
   showDirectionLine?: boolean;
 }
 
-export const CurrentMarker = (props: Props) => {
+// 不要な再レンダリングを防ぐカスタム比較（HomeCompassButtonと同方針）。
+// azimuthは磁気センサー由来のノイズで頻繁に変わるため、約1°超の変化のみ再レンダリングする。
+const arePropsEqual = (prev: Props, next: Props) => {
+  if (prev.headingUp !== next.headingUp) return false;
+  if (prev.onPress !== next.onPress) return false;
+  if (prev.showDirectionLine !== next.showDirectionLine) return false;
+
+  const a = prev.currentLocation;
+  const b = next.currentLocation;
+  if (a.latitude !== b.latitude || a.longitude !== b.longitude || (a.accuracy ?? 0) !== (b.accuracy ?? 0)) {
+    return false;
+  }
+
+  if (Math.abs(prev.azimuth - next.azimuth) > 1) return false;
+
+  return true;
+};
+
+const CurrentMarkerComponent = (props: Props) => {
   const { currentLocation, azimuth, headingUp, onPress, showDirectionLine } = props;
   const accuracy = currentLocation.accuracy ?? 0;
   const fillColor = accuracy > 30 ? '#bbbbbbaa' : accuracy > 15 ? '#ff9900aa' : '#ff0000aa';
@@ -114,3 +132,5 @@ export const CurrentMarker = (props: Props) => {
     </>
   );
 };
+
+export const CurrentMarker = React.memo(CurrentMarkerComponent, arePropsEqual);

--- a/src/hooks/__tests__/useLocation.test.ts
+++ b/src/hooks/__tests__/useLocation.test.ts
@@ -2,7 +2,8 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import React from 'react';
-import { useLocation, shouldEmitAzimuth } from '../useLocation';
+import { AppState } from 'react-native';
+import { useLocation, shouldEmitAzimuth, angularDeltaDeg, shouldRotateCompassCamera } from '../useLocation';
 import * as Location from 'expo-location';
 import BackgroundGeolocation from 'react-native-background-geolocation';
 import { ConfirmAsync, AlertAsync } from '../../components/molecules/AlertAsync';
@@ -89,6 +90,12 @@ jest.mock('../../utils/Location', () => ({
     displayBufferSize: 0,
   })),
   addLocationsToChunks: jest.fn(),
+  flushTrackLog: jest.fn(),
+  getLineLength: jest.fn(() => 0),
+  toLocationObject: jest.fn((location: any) => ({
+    coords: { ...location.coords },
+    timestamp: location.timestamp,
+  })),
 }));
 
 jest.mock('../../utils/mmkvStorage', () => ({
@@ -330,5 +337,228 @@ describe('shouldEmitAzimuth', () => {
     expect(shouldEmitAzimuth(359, 359.5, 300, THROTTLE, MIN_DELTA)).toBe(false);
     // 0→359 は -1°（更新）
     expect(shouldEmitAzimuth(0, 359, 300, THROTTLE, MIN_DELTA)).toBe(true);
+  });
+});
+
+describe('angularDeltaDeg', () => {
+  it('通常の角度差を返す', () => {
+    expect(angularDeltaDeg(10, 30)).toBe(20);
+    expect(angularDeltaDeg(30, 10)).toBe(20);
+    expect(angularDeltaDeg(90, 90)).toBe(0);
+  });
+
+  it('0/360のラップを考慮する', () => {
+    expect(angularDeltaDeg(350, 10)).toBe(20);
+    expect(angularDeltaDeg(10, 350)).toBe(20);
+    expect(angularDeltaDeg(0, 180)).toBe(180);
+  });
+});
+
+describe('shouldRotateCompassCamera', () => {
+  const MIN_INTERVAL = 100;
+  const MIN_DELTA = 2;
+
+  it('初回(prev=null)は間隔・角度差に関わらず回転する', () => {
+    expect(shouldRotateCompassCamera(null, 90, 0, MIN_INTERVAL, MIN_DELTA)).toBe(true);
+  });
+
+  it('最小間隔未満ではスキップする', () => {
+    expect(shouldRotateCompassCamera(0, 90, 50, MIN_INTERVAL, MIN_DELTA)).toBe(false);
+  });
+
+  it('角度差がしきい値未満ならスキップする', () => {
+    expect(shouldRotateCompassCamera(10, 11, 300, MIN_INTERVAL, MIN_DELTA)).toBe(false);
+  });
+
+  it('同じ角度（差0）はスキップする', () => {
+    // 旧実装の headingDiff > 0 条件では差0が回転扱いになるバグがあった（回帰テスト）
+    expect(shouldRotateCompassCamera(90, 90, 300, MIN_INTERVAL, MIN_DELTA)).toBe(false);
+  });
+
+  it('0/360のラップを考慮して角度差を計算する', () => {
+    // 359→1 は +2°（回転）
+    expect(shouldRotateCompassCamera(359, 1, 300, MIN_INTERVAL, MIN_DELTA)).toBe(true);
+    // 359→0.5 は +1.5°（スキップ）
+    expect(shouldRotateCompassCamera(359, 0.5, 300, MIN_INTERVAL, MIN_DELTA)).toBe(false);
+  });
+});
+
+describe('バックグラウンド中のUI更新スキップ', () => {
+  let store: any;
+  let wrapper: any;
+
+  const fireLocation = (callback: (location: any) => void, latitude: number, longitude: number) => {
+    callback({
+      coords: { latitude, longitude, altitude: 0, accuracy: 5, heading: 0, speed: 1 },
+      timestamp: Date.now(),
+    });
+  };
+
+  beforeEach(() => {
+    store = createTestStore();
+    wrapper = createWrapper(store);
+    jest.clearAllMocks();
+    (ConfirmAsync as jest.Mock).mockResolvedValue(false);
+    mockBackgroundGeolocation.ready.mockResolvedValue({ enabled: false } as any);
+    mockBackgroundGeolocation.getState.mockResolvedValue({ enabled: false } as any);
+    mockBackgroundGeolocation.removeListeners.mockResolvedValue(undefined);
+    mockBackgroundGeolocation.requestPermission.mockResolvedValue(BackgroundGeolocation.AuthorizationStatus.Always);
+    mockBackgroundGeolocation.getCurrentPosition.mockResolvedValue({
+      coords: { latitude: 35.0, longitude: 135.0, altitude: 0, accuracy: 10, altitudeAccuracy: 5, heading: 0, speed: 0 },
+      timestamp: Date.now(),
+    } as any);
+    mockBackgroundGeolocation.onLocation.mockReturnValue({ remove: jest.fn() } as any);
+    mockLocation.watchHeadingAsync.mockResolvedValue({ remove: jest.fn() });
+    mockNotifications.getPermissionsAsync.mockResolvedValue({ status: 'granted' } as any);
+    (AppState as any).currentState = 'active';
+  });
+
+  afterEach(() => {
+    (AppState as any).currentState = 'active';
+  });
+
+  it('background中はcurrentLocation更新とカメラ移動をスキップする（MMKV保存は継続）', async () => {
+    const { trackLogMMKV } = require('../../utils/mmkvStorage');
+    const mockMapRef = { current: { animateCamera: jest.fn() } };
+    const { result } = renderHook(() => useLocation(mockMapRef as any), { wrapper });
+
+    await act(async () => {
+      await result.current.toggleGPS('follow');
+    });
+
+    const onLocationCallback = mockBackgroundGeolocation.onLocation.mock.calls[0][0];
+    const locationBefore = result.current.currentLocation;
+    mockMapRef.current.animateCamera.mockClear();
+    (trackLogMMKV.setCurrentLocation as jest.Mock).mockClear();
+
+    (AppState as any).currentState = 'background';
+    act(() => {
+      fireLocation(onLocationCallback, 36.5, 136.5);
+    });
+
+    // React stateとカメラは更新されない
+    expect(result.current.currentLocation).toEqual(locationBefore);
+    expect(mockMapRef.current.animateCamera).not.toHaveBeenCalled();
+    // MMKVへの現在地保存は継続される（復帰時の同期用）
+    expect(trackLogMMKV.setCurrentLocation).toHaveBeenCalledWith(
+      expect.objectContaining({ latitude: 36.5, longitude: 136.5 })
+    );
+  });
+
+  it('active中は従来どおりcurrentLocation更新とfollowカメラ移動を行う', async () => {
+    const mockMapRef = { current: { animateCamera: jest.fn() } };
+    const { result } = renderHook(() => useLocation(mockMapRef as any), { wrapper });
+
+    await act(async () => {
+      await result.current.toggleGPS('follow');
+    });
+
+    const onLocationCallback = mockBackgroundGeolocation.onLocation.mock.calls[0][0];
+    mockMapRef.current.animateCamera.mockClear();
+
+    act(() => {
+      fireLocation(onLocationCallback, 36.5, 136.5);
+    });
+
+    expect(result.current.currentLocation).toEqual(expect.objectContaining({ latitude: 36.5, longitude: 136.5 }));
+    expect(mockMapRef.current.animateCamera).toHaveBeenCalledWith(
+      { center: { latitude: 36.5, longitude: 136.5 } },
+      { duration: 5 }
+    );
+  });
+});
+
+describe('heading購読のライフサイクル', () => {
+  let store: any;
+  let wrapper: any;
+
+  beforeEach(() => {
+    store = createTestStore();
+    wrapper = createWrapper(store);
+    jest.clearAllMocks();
+    (ConfirmAsync as jest.Mock).mockResolvedValue(false);
+    mockBackgroundGeolocation.ready.mockResolvedValue({ enabled: false } as any);
+    mockBackgroundGeolocation.getState.mockResolvedValue({ enabled: false } as any);
+    mockBackgroundGeolocation.removeListeners.mockResolvedValue(undefined);
+    mockBackgroundGeolocation.requestPermission.mockResolvedValue(BackgroundGeolocation.AuthorizationStatus.Always);
+    mockBackgroundGeolocation.getCurrentPosition.mockResolvedValue({
+      coords: { latitude: 35.0, longitude: 135.0, altitude: 0, accuracy: 10, altitudeAccuracy: 5, heading: 0, speed: 0 },
+      timestamp: Date.now(),
+    } as any);
+    mockBackgroundGeolocation.onLocation.mockReturnValue({ remove: jest.fn() } as any);
+    mockNotifications.getPermissionsAsync.mockResolvedValue({ status: 'granted' } as any);
+    (AppState as any).currentState = 'active';
+  });
+
+  it('コンパスOFF後もGPS ON中は通常のheading購読を復元する', async () => {
+    mockLocation.watchHeadingAsync.mockResolvedValue({ remove: jest.fn() });
+    const mockMapRef = { current: { animateCamera: jest.fn() } };
+    const { result } = renderHook(() => useLocation(mockMapRef as any), { wrapper });
+
+    await act(async () => {
+      await result.current.toggleGPS('show');
+    });
+    const callsAfterGpsOn = mockLocation.watchHeadingAsync.mock.calls.length;
+    expect(callsAfterGpsOn).toBeGreaterThanOrEqual(1);
+
+    await act(async () => {
+      await result.current.toggleHeadingUp(true);
+    });
+    expect(mockLocation.watchHeadingAsync.mock.calls.length).toBe(callsAfterGpsOn + 1);
+
+    await act(async () => {
+      await result.current.toggleHeadingUp(false);
+    });
+    // コンパスOFF後に通常購読が復元される（修正前は購読が消えてマーカーの向きが凍結していた）
+    expect(mockLocation.watchHeadingAsync.mock.calls.length).toBe(callsAfterGpsOn + 2);
+  });
+
+  it('トラッキング停止時にheading購読を解除する', async () => {
+    const removeMock = jest.fn();
+    mockLocation.watchHeadingAsync.mockResolvedValue({ remove: removeMock });
+    const mockMapRef = { current: { animateCamera: jest.fn() } };
+    const { result } = renderHook(() => useLocation(mockMapRef as any), { wrapper });
+
+    await act(async () => {
+      await result.current.toggleTracking('on');
+    });
+    removeMock.mockClear();
+
+    await act(async () => {
+      await result.current.toggleTracking('off');
+    });
+    expect(removeMock).toHaveBeenCalled();
+  });
+
+  it('トラッキング開始後の状態変化でonLocation/heading購読が破棄されない（初期化effect再実行の回帰）', async () => {
+    // 旧実装では初期化effectの依存配列にtrackingState等が含まれており、
+    // 依存変化時のクリーンアップで購読が破棄され、再購読されないまま位置・方位の更新が止まることがあった
+    const headingRemove = jest.fn();
+    mockLocation.watchHeadingAsync.mockResolvedValue({ remove: headingRemove });
+    const locationRemove = jest.fn();
+    mockBackgroundGeolocation.onLocation.mockReturnValue({ remove: locationRemove });
+    const mockMapRef = { current: { animateCamera: jest.fn() } };
+    const { result } = renderHook(() => useLocation(mockMapRef as any), { wrapper });
+
+    await act(async () => {
+      await result.current.toggleGPS('follow');
+    });
+    await act(async () => {
+      await result.current.toggleTracking('on');
+    });
+
+    // trackingStateの変化（再レンダリング）後も購読は維持される
+    expect(locationRemove).not.toHaveBeenCalled();
+    expect(headingRemove).not.toHaveBeenCalled();
+
+    // 位置イベントが引き続き反映される
+    const onLocationCallback = mockBackgroundGeolocation.onLocation.mock.calls[0][0];
+    act(() => {
+      onLocationCallback({
+        coords: { latitude: 36.1, longitude: 136.1, altitude: 0, accuracy: 5, heading: 0, speed: 1 },
+        timestamp: Date.now(),
+      });
+    });
+    expect(result.current.currentLocation).toEqual(expect.objectContaining({ latitude: 36.1, longitude: 136.1 }));
   });
 });

--- a/src/hooks/__tests__/useLocation.test.ts
+++ b/src/hooks/__tests__/useLocation.test.ts
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import React from 'react';
-import { useLocation } from '../useLocation';
+import { useLocation, shouldEmitAzimuth } from '../useLocation';
 import * as Location from 'expo-location';
 import BackgroundGeolocation from 'react-native-background-geolocation';
 import { ConfirmAsync, AlertAsync } from '../../components/molecules/AlertAsync';
@@ -296,5 +296,39 @@ describe('useLocation', () => {
 
     // Clean up
     consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('shouldEmitAzimuth', () => {
+  const THROTTLE = 200;
+  const MIN_DELTA = 1;
+
+  it('初回(prev=null)は十分時間が経っていれば更新する', () => {
+    expect(shouldEmitAzimuth(null, 90, 1000, THROTTLE, MIN_DELTA)).toBe(true);
+  });
+
+  it('初回でもthrottle未満の間隔ではスキップする', () => {
+    expect(shouldEmitAzimuth(null, 90, 50, THROTTLE, MIN_DELTA)).toBe(false);
+  });
+
+  it('throttle間隔未満ではスキップする（頻度制限）', () => {
+    expect(shouldEmitAzimuth(10, 90, 50, THROTTLE, MIN_DELTA)).toBe(false);
+  });
+
+  it('角度差がしきい値未満ならスキップする', () => {
+    expect(shouldEmitAzimuth(10, 10.5, 300, THROTTLE, MIN_DELTA)).toBe(false);
+  });
+
+  it('角度差がしきい値以上なら更新する', () => {
+    expect(shouldEmitAzimuth(10, 12, 300, THROTTLE, MIN_DELTA)).toBe(true);
+  });
+
+  it('0/360のラップを考慮して角度差を計算する', () => {
+    // 359→1 は +2°
+    expect(shouldEmitAzimuth(359, 1, 300, THROTTLE, MIN_DELTA)).toBe(true);
+    // 359→359.5 は +0.5°（スキップ）
+    expect(shouldEmitAzimuth(359, 359.5, 300, THROTTLE, MIN_DELTA)).toBe(false);
+    // 0→359 は -1°（更新）
+    expect(shouldEmitAzimuth(0, 359, 300, THROTTLE, MIN_DELTA)).toBe(true);
   });
 });

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -21,6 +21,7 @@ import {
   getCurrentChunkInfo,
   getLineLength,
   toLocationObject,
+  flushTrackLog,
 } from '../utils/Location';
 import { trackLogMMKV } from '../utils/mmkvStorage';
 import { hasOpened } from '../utils/Project';
@@ -47,6 +48,9 @@ const openSettings = () => {
 // ネイティブAPIは依然としてフラットなトップレベルnotificationを要求する（型とランタイムの不整合）。
 // その差異を吸収するためのローカル型。
 type FlatConfig = Partial<BackgroundConfig> & { notification: NotificationConfig };
+
+// 軌跡ライン（trailing polyline）の再描画を約1秒ごとにスロットルするための間隔
+const TRACK_META_UPDATE_INTERVAL_MS = 1000;
 
 export type UseLocationReturnType = {
   currentLocation: LocationType | null;
@@ -103,6 +107,11 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
   const locationSubscription = useRef<BackgroundSubscription | null>(null);
   const gpsAccuracy = useSelector((state: RootState) => state.settings.gpsAccuracy);
   const appState = useRef(RNAppState.currentState);
+  // トラックメタデータ(=軌跡ライン再描画)の更新を約1秒にスロットルする。
+  // 現在地マーカーは setCurrentLocation で毎点更新するため滑らかさは維持される。
+  const lastTrackMetaUpdateRef = useRef(0);
+  // チャンクのrollover（savedChunkCount変化）時はスロットルを無視して即時反映する。
+  const lastSavedChunkIndexRef = useRef(0);
   const [currentLocation, setCurrentLocation] = useState<LocationType | null>(null);
   const [headingUp, setHeadingUp] = useState(false);
   const [gpsState, setGpsState] = useState<LocationStateType>('off');
@@ -183,19 +192,26 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
 
         // トラッキング中のみ軌跡を保存
         if (isTracking) {
-          checkAndStoreLocations([normalized]);
+          // checkAndStoreLocationsが更新後のmetadata/現在チャンクを返すため、ここでの再読み込みは不要
+          const result = checkAndStoreLocations([normalized]);
 
-          // メタデータを更新
-          const chunkInfo = getCurrentChunkInfo();
-          const metadata = getTrackMetadata();
-          setTrackMetadata({
-            distance: metadata.currentDistance,
-            lastTimeStamp: metadata.lastTimeStamp,
-            savedChunkCount: chunkInfo.currentChunkIndex,
-            currentChunkSize: chunkInfo.currentChunkSize,
-            totalPoints: metadata.totalPoints,
-            currentLocation: latest,
-          });
+          if (result) {
+            // 軌跡ラインの再描画は約1秒にスロットル（rollover=savedChunkCount変化時は即時反映）。
+            const now = Date.now();
+            const chunkChanged = result.metadata.lastChunkIndex !== lastSavedChunkIndexRef.current;
+            if (chunkChanged || now - lastTrackMetaUpdateRef.current >= TRACK_META_UPDATE_INTERVAL_MS) {
+              lastTrackMetaUpdateRef.current = now;
+              lastSavedChunkIndexRef.current = result.metadata.lastChunkIndex;
+              setTrackMetadata({
+                distance: result.metadata.currentDistance,
+                lastTimeStamp: result.metadata.lastTimeStamp,
+                savedChunkCount: result.metadata.lastChunkIndex,
+                currentChunkSize: result.chunk.length,
+                totalPoints: result.metadata.totalPoints,
+                currentLocation: latest,
+              });
+            }
+          }
         }
 
         // GPSオンまたはトラッキング中は現在地をMMKVに保存（フォアグラウンド復帰時の同期用）
@@ -342,6 +358,8 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
 
   const stopTracking = useCallback(async () => {
     try {
+      // メモリ内の未書き込みポイントをMMKVへ確定（停止後にsaveTrackLog/破棄で正しく読めるように）
+      flushTrackLog();
       await ensureBackgroundGeolocation();
       // 軌跡記録停止時はBackgroundGeolocationも停止
       const state: BackgroundState = await BackgroundGeolocation.getState();
@@ -865,6 +883,9 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
       } else if (appState.current === 'active' && nextAppState.match(/inactive|background/)) {
         // バックグラウンド移行時
         // BackgroundGeolocationは継続（onLocationで位置更新を続ける）
+
+        // メモリ内の未書き込みポイントをMMKVへ確定（この後アプリがkillされてもheadlessが続きから記録できるように）
+        flushTrackLog();
 
         // ヘディング購読を停止（バッテリー節約）
         if (headingSubscriber.current !== null) {

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -52,6 +52,32 @@ type FlatConfig = Partial<BackgroundConfig> & { notification: NotificationConfig
 // 軌跡ライン（trailing polyline）の再描画を約1秒ごとにスロットルするための間隔
 const TRACK_META_UPDATE_INTERVAL_MS = 1000;
 
+// 方位(azimuth)の state 更新を間引くための設定。
+// 磁気センサーは毎秒数十回発火するため、そのまま setAzimuth すると Home 配下が高頻度再レンダリングして
+// 方位表示が「ふらふら」する/もたつく。頻度と最小角度差で間引いて再描画を抑制する。
+const AZIMUTH_THROTTLE_MS = 200; // 最大 5 回/秒
+const AZIMUTH_MIN_DELTA_DEG = 1; // 1°未満の変化は無視（静止時のノイズで再描画しない）
+
+/**
+ * 方位の state を更新すべきか判定する純粋関数。
+ * - 直前更新から throttleMs 未満ならスキップ（頻度制限）
+ * - 直前値との角度差（0-360のラップを考慮）が minDeltaDeg 未満ならスキップ
+ * - 初回（prevDeg が null）は常に更新
+ */
+export const shouldEmitAzimuth = (
+  prevDeg: number | null,
+  nextDeg: number,
+  msSinceLast: number,
+  throttleMs: number,
+  minDeltaDeg: number
+): boolean => {
+  if (msSinceLast < throttleMs) return false;
+  if (prevDeg === null) return true;
+  // 角度のラップを考慮した絶対差（0..180）
+  const delta = Math.abs(((nextDeg - prevDeg + 540) % 360) - 180);
+  return delta >= minDeltaDeg;
+};
+
 export type UseLocationReturnType = {
   currentLocation: LocationType | null;
   gpsState: LocationStateType;
@@ -100,6 +126,11 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
   const checkProximityRef = useRef(checkProximity);
   const [azimuth, setAzimuth] = useState(0);
   const headingSubscriber = useRef<LocationSubscription | null>(null);
+  // 方位スロットル用（最後に反映した角度と時刻）
+  const lastAzimuthRef = useRef<number | null>(null);
+  const lastAzimuthTsRef = useRef(0);
+  // heading購読の競合による二重購読を防ぐためのフラグ
+  const headingSubscribingRef = useRef(false);
   const bgReadyRef = useRef(false);
   const initializedRef = useRef(false);
   const trackingStateRef = useRef<TrackingStateType>('off');
@@ -134,6 +165,32 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
         return { desiredAccuracy: BackgroundGeolocation.DesiredAccuracy.High, distanceFilter: 2 };
     }
   }, [gpsAccuracy]);
+
+  // 方位を間引いて反映する（頻度制限＋最小角度差）。全てのheadingコールバックはこれを使う。
+  const pushAzimuth = useCallback((heading: number) => {
+    const now = Date.now();
+    if (!shouldEmitAzimuth(lastAzimuthRef.current, heading, now - lastAzimuthTsRef.current, AZIMUTH_THROTTLE_MS, AZIMUTH_MIN_DELTA_DEG)) {
+      return;
+    }
+    lastAzimuthRef.current = heading;
+    lastAzimuthTsRef.current = now;
+    setAzimuth(heading);
+  }, []);
+
+  // 通常（コンパスOFF）用のheading購読を保証する。既に購読中/購読処理中なら何もしない（多重購読防止）。
+  const ensureHeadingSubscription = useCallback(async () => {
+    if (headingSubscriber.current !== null || headingSubscribingRef.current) return;
+    headingSubscribingRef.current = true;
+    try {
+      headingSubscriber.current = await watchHeadingAsync((pos) => {
+        pushAzimuth(pos.trueHeading);
+      });
+    } catch (error) {
+      console.error('Failed to start heading subscriber:', error);
+    } finally {
+      headingSubscribingRef.current = false;
+    }
+  }, [pushAzimuth]);
 
   // checkProximityをrefで同期（onLocationコールバックがクロージャで古い参照を保持する問題を回避）
   useEffect(() => {
@@ -329,17 +386,9 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
         }
       }
 
-      if (headingSubscriber.current === null) {
-        try {
-          headingSubscriber.current = await watchHeadingAsync((pos) => {
-            setAzimuth(pos.trueHeading);
-          });
-        } catch (error) {
-          console.error('Failed to start heading subscriber:', error);
-        }
-      }
+      await ensureHeadingSubscription();
     },
-    [ensureBackgroundGeolocation]
+    [ensureBackgroundGeolocation, ensureHeadingSubscription]
   );
 
   const stopGPS = useCallback(async () => {
@@ -416,16 +465,12 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
       // トラッキング状態をMMKVに保存（kill後の復帰で正しく復元するため）
       trackLogMMKV.setTrackingState('on');
 
-      if (headingSubscriber.current === null) {
-        headingSubscriber.current = await watchHeadingAsync((pos) => {
-          setAzimuth(pos.trueHeading);
-        });
-      }
+      await ensureHeadingSubscription();
     } catch (error) {
       console.error('Error in startTracking:', error);
       throw error;
     }
-  }, [ensureBackgroundGeolocation]);
+  }, [ensureBackgroundGeolocation, ensureHeadingSubscription]);
 
   const moveCurrentPosition = useCallback(async () => {
     try {
@@ -515,7 +560,10 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
         const permissionStatus = await confirmLocationPermission();
         if (permissionStatus !== 'granted') return;
 
-        if (headingSubscriber.current !== null) headingSubscriber.current.remove();
+        if (headingSubscriber.current !== null) {
+          headingSubscriber.current.remove();
+          headingSubscriber.current = null;
+        }
 
         let lastHeading = 0;
         let lastUpdateTime = 0;
@@ -527,14 +575,14 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
           // 角度の変化が小さい場合はアニメーションをスキップ
           const headingDiff = Math.abs(newHeading - lastHeading);
           if (headingDiff < 2 && headingDiff > 0) {
-            setAzimuth(pos.trueHeading);
+            pushAzimuth(pos.trueHeading);
             return;
           }
 
           // 最小更新間隔を設定（ミリ秒）
           const minUpdateInterval = 100;
           if (currentTime - lastUpdateTime < minUpdateInterval) {
-            setAzimuth(pos.trueHeading);
+            pushAzimuth(pos.trueHeading);
             return;
           }
 
@@ -548,7 +596,7 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
             { duration: 200 }
           );
 
-          setAzimuth(pos.trueHeading);
+          pushAzimuth(pos.trueHeading);
         });
       } else {
         // headingUpをfalseにする場合は権限不要
@@ -566,7 +614,7 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
       }
       setHeadingUp(headingUp_);
     },
-    [confirmLocationPermission, mapViewRef]
+    [confirmLocationPermission, mapViewRef, pushAzimuth]
   );
 
   // フォアグラウンド復帰時にMMKVからデータを同期する関数
@@ -775,9 +823,7 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
               if (permissionStatus !== 'granted') {
                 console.warn('[tracking] Heading subscription skipped: permission not granted');
               } else {
-                headingSubscriber.current = await watchHeadingAsync((pos) => {
-                  setAzimuth(pos.trueHeading);
-                });
+                await ensureHeadingSubscription();
               }
             } catch (error) {
               console.error('Error restoring heading subscriber:', error);
@@ -813,9 +859,7 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
             try {
               const permissionStatus = await confirmLocationPermission();
               if (permissionStatus === 'granted') {
-                headingSubscriber.current = await watchHeadingAsync((pos) => {
-                  setAzimuth(pos.trueHeading);
-                });
+                await ensureHeadingSubscription();
               }
             } catch (error) {
               console.error('Error starting heading subscriber:', error);
@@ -847,6 +891,7 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
     checkUnsavedTrackLog,
     confirmLocationPermission,
     ensureBackgroundGeolocation,
+    ensureHeadingSubscription,
     stopTracking,
     trackingState,
     moveCurrentPosition,
@@ -868,9 +913,7 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
           try {
             const permissionStatus = await confirmLocationPermission();
             if (permissionStatus === 'granted') {
-              headingSubscriber.current = await watchHeadingAsync((pos) => {
-                setAzimuth(pos.trueHeading);
-              });
+              await ensureHeadingSubscription();
             } else {
               console.warn('[tracking] Skipped heading subscription on foreground: permission not granted');
             }
@@ -907,6 +950,7 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
     trackingState,
     syncLocationFromMMKV,
     confirmLocationPermission,
+    ensureHeadingSubscription,
   ]);
 
   useEffect(() => {

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -49,6 +49,21 @@ const openSettings = () => {
 // その差異を吸収するためのローカル型。
 type FlatConfig = Partial<BackgroundConfig> & { notification: NotificationConfig };
 
+// disableStopDetection等もv5の型ではgeolocation/activity配下にネストされているが、
+// ネイティブAPIはフラットなトップレベルキーを要求する（notificationと同様の不整合）。
+type FlatStopDetectionConfig = Partial<BackgroundConfig> & {
+  disableStopDetection: boolean;
+  pausesLocationUpdatesAutomatically: boolean;
+};
+
+// 静止しても記録が勝手に止まらないように静止検出を無効化する設定（常時記録方針）。
+// iOSは自動電源オフを完全に防ぐためにdisableStopDetectionとpausesLocationUpdatesAutomatically:false
+// の両方が必要（公式ドキュメント推奨の組み合わせ）。
+const STOP_DETECTION_DISABLED: FlatStopDetectionConfig = {
+  disableStopDetection: true,
+  pausesLocationUpdatesAutomatically: false,
+};
+
 // 軌跡ライン（trailing polyline）の再描画を約1秒ごとにスロットルするための間隔
 const TRACK_META_UPDATE_INTERVAL_MS = 1000;
 
@@ -57,6 +72,13 @@ const TRACK_META_UPDATE_INTERVAL_MS = 1000;
 // 方位表示が「ふらふら」する/もたつく。頻度と最小角度差で間引いて再描画を抑制する。
 const AZIMUTH_THROTTLE_MS = 200; // 最大 5 回/秒
 const AZIMUTH_MIN_DELTA_DEG = 1; // 1°未満の変化は無視（静止時のノイズで再描画しない）
+
+// コンパスモード（headingUp）でのカメラ回転の間引き設定
+const COMPASS_CAMERA_MIN_INTERVAL_MS = 100;
+const COMPASS_CAMERA_MIN_DELTA_DEG = 2;
+
+// 角度のラップ（0/360のまたぎ）を考慮した絶対差（0..180）
+export const angularDeltaDeg = (a: number, b: number): number => Math.abs(((b - a + 540) % 360) - 180);
 
 /**
  * 方位の state を更新すべきか判定する純粋関数。
@@ -73,9 +95,25 @@ export const shouldEmitAzimuth = (
 ): boolean => {
   if (msSinceLast < throttleMs) return false;
   if (prevDeg === null) return true;
-  // 角度のラップを考慮した絶対差（0..180）
-  const delta = Math.abs(((nextDeg - prevDeg + 540) % 360) - 180);
-  return delta >= minDeltaDeg;
+  return angularDeltaDeg(prevDeg, nextDeg) >= minDeltaDeg;
+};
+
+/**
+ * コンパスモードでカメラを回転すべきか判定する純粋関数。
+ * - 初回（prevDeg が null）は常に回転（カメラが任意の向きで止まっている可能性があるため）
+ * - 直前回転から minIntervalMs 未満ならスキップ
+ * - 直前値との角度差（0-360のラップを考慮）が minDeltaDeg 未満ならスキップ
+ */
+export const shouldRotateCompassCamera = (
+  prevDeg: number | null,
+  nextDeg: number,
+  msSinceLast: number,
+  minIntervalMs: number,
+  minDeltaDeg: number
+): boolean => {
+  if (prevDeg === null) return true;
+  if (msSinceLast < minIntervalMs) return false;
+  return angularDeltaDeg(prevDeg, nextDeg) >= minDeltaDeg;
 };
 
 export type UseLocationReturnType = {
@@ -247,12 +285,18 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
         const normalized = toLocationObject(location);
         const latest = { ...normalized.coords, timestamp: normalized.timestamp };
 
+        // バックグラウンド中は画面が見えないため、React state更新とカメラ移動をスキップして
+        // CPU/ブリッジ消費を抑える（MMKVへの保存と接近通知は継続。
+        // 表示はフォアグラウンド復帰時にsyncLocationFromMMKVで復元される）。
+        // 'inactive'（iOSのApp Switcher等、画面がまだ見える状態）はUI更新を継続する。
+        const isInBackground = RNAppState.currentState === 'background';
+
         // トラッキング中のみ軌跡を保存
         if (isTracking) {
           // checkAndStoreLocationsが更新後のmetadata/現在チャンクを返すため、ここでの再読み込みは不要
           const result = checkAndStoreLocations([normalized]);
 
-          if (result) {
+          if (result && !isInBackground) {
             // 軌跡ラインの再描画は約1秒にスロットル（rollover=savedChunkCount変化時は即時反映）。
             const now = Date.now();
             const chunkChanged = result.metadata.lastChunkIndex !== lastSavedChunkIndexRef.current;
@@ -274,25 +318,27 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
         // GPSオンまたはトラッキング中は現在地をMMKVに保存（フォアグラウンド復帰時の同期用）
         trackLogMMKV.setCurrentLocation(latest);
 
-        // 常に現在地を更新
-        setCurrentLocation(latest);
+        if (!isInBackground) {
+          // 現在地を更新
+          setCurrentLocation(latest);
 
-        // カメラ移動（followモードまたはバックグラウンド時のトラッキング中）
-        if (gpsStateRef.current === 'follow' || (isTracking && RNAppState.currentState === 'background')) {
-          if (mapViewRef.current !== null && isMapView(mapViewRef.current)) {
-            (mapViewRef.current as MapView).animateCamera(
-              {
-                center: {
-                  latitude: latest.latitude,
-                  longitude: latest.longitude,
+          // カメラ移動（followモード時）
+          if (gpsStateRef.current === 'follow') {
+            if (mapViewRef.current !== null && isMapView(mapViewRef.current)) {
+              (mapViewRef.current as MapView).animateCamera(
+                {
+                  center: {
+                    latitude: latest.latitude,
+                    longitude: latest.longitude,
+                  },
                 },
-              },
-              { duration: 5 }
-            );
+                { duration: 5 }
+              );
+            }
           }
         }
 
-        // 接近通知チェック（GPSオンまたはトラッキング中）
+        // 接近通知チェック（GPSオンまたはトラッキング中。バックグラウンドでも継続）
         checkProximityRef.current(latest);
       } catch (error) {
         console.error('[tracking] Failed to persist location', error);
@@ -325,6 +371,7 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
       locationAuthorizationRequest: 'WhenInUse',
       disableLocationAuthorizationAlert: true,
       disableMotionActivityUpdates: true,
+      ...STOP_DETECTION_DISABLED,
       notification: {
         sticky: true,
         title: 'EcorisMap',
@@ -341,6 +388,12 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
     } as const;
 
     const state = await BackgroundGeolocation.ready(config);
+
+    // reset:falseの場合（kill後復帰などサービス稼働中）はready()で設定が適用されないため、
+    // 稼働中のサービスにも静止検出の無効化を明示的に反映する。
+    if (isServiceRunning) {
+      await BackgroundGeolocation.setConfig(STOP_DETECTION_DISABLED);
+    }
 
     if (!locationSubscription.current) {
       locationSubscription.current = BackgroundGeolocation.onLocation(
@@ -423,6 +476,11 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
       trackLogMMKV.setGpsState('off');
       // React Stateをクリア（メモリ解放を促進）
       setCurrentLocation(null);
+      // heading購読を解除（stopGPSと対称。磁気センサーの購読が残るのを防ぐ）
+      if (headingSubscriber.current !== null) {
+        headingSubscriber.current.remove();
+        headingSubscriber.current = null;
+      }
     } catch (e) {
     } finally {
       if (isLoggedIn(dataUser) && hasOpened(projectId)) {
@@ -540,7 +598,7 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
           setTrackingState(trackingState_);
           trackingStateRef.current = trackingState_;
           await stopTracking();
-          // GPSがオンの場合はstopTracking内でBackgroundGeolocationは継続している
+          // stopTrackingはGPSも停止する（UIフローでは続けてtoggleGPS('off')が呼ばれ状態が整合する）
         }
       } catch (error) {
         console.error('Error in toggleTracking:', error);
@@ -565,23 +623,25 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
           headingSubscriber.current = null;
         }
 
-        let lastHeading = 0;
+        let lastHeading: number | null = null;
         let lastUpdateTime = 0;
 
         headingSubscriber.current = await watchHeadingAsync((pos) => {
-          const newHeading = Math.abs((-1.0 * pos.trueHeading) % 360);
+          // iOSでtrue headingが取得できない場合は-1が返る（不正値は無視）
+          if (pos.trueHeading < 0) return;
+          const newHeading = pos.trueHeading % 360;
           const currentTime = Date.now();
 
-          // 角度の変化が小さい場合はアニメーションをスキップ
-          const headingDiff = Math.abs(newHeading - lastHeading);
-          if (headingDiff < 2 && headingDiff > 0) {
-            pushAzimuth(pos.trueHeading);
-            return;
-          }
-
-          // 最小更新間隔を設定（ミリ秒）
-          const minUpdateInterval = 100;
-          if (currentTime - lastUpdateTime < minUpdateInterval) {
+          // 角度の変化が小さい/間隔が短い場合はカメラ回転をスキップ（方位stateは更新）
+          if (
+            !shouldRotateCompassCamera(
+              lastHeading,
+              newHeading,
+              currentTime - lastUpdateTime,
+              COMPASS_CAMERA_MIN_INTERVAL_MS,
+              COMPASS_CAMERA_MIN_DELTA_DEG
+            )
+          ) {
             pushAzimuth(pos.trueHeading);
             return;
           }
@@ -611,10 +671,15 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
           },
           { duration: 500 }
         );
+
+        // GPS/トラッキング中はマーカーの向き表示にazimuthが必要なため、通常のheading購読を復元する
+        if (gpsStateRef.current !== 'off' || trackingStateRef.current === 'on') {
+          await ensureHeadingSubscription();
+        }
       }
       setHeadingUp(headingUp_);
     },
-    [confirmLocationPermission, mapViewRef, pushAzimuth]
+    [confirmLocationPermission, ensureHeadingSubscription, mapViewRef, pushAzimuth]
   );
 
   // フォアグラウンド復帰時にMMKVからデータを同期する関数
@@ -626,6 +691,9 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
     if (trackingStateRef.current === 'on') {
       const chunkInfo = getCurrentChunkInfo();
       const metadata = getTrackMetadata();
+      // スロットル用refも同期（バックグラウンド中にrolloverしていた場合の余分な即時更新を防ぐ）
+      lastSavedChunkIndexRef.current = chunkInfo.currentChunkIndex;
+      lastTrackMetaUpdateRef.current = Date.now();
       setTrackMetadata({
         distance: metadata.currentDistance,
         lastTimeStamp: metadata.lastTimeStamp,
@@ -636,8 +704,9 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
       });
     }
 
-    // カメラ移動（followモード時）
-    if (gpsStateRef.current === 'follow') {
+    // カメラ移動（followモード時、またはトラッキング中。
+    // バックグラウンド中はカメラ追従を止めているため、復帰時に1回だけ現在地へセンタリングしてUXを維持する）
+    if (gpsStateRef.current === 'follow' || trackingStateRef.current === 'on') {
       if (mapViewRef.current !== null && isMapView(mapViewRef.current)) {
         (mapViewRef.current as MapView).animateCamera(
           {
@@ -887,15 +956,12 @@ export const useLocation = (mapViewRef: React.RefObject<MapView | MapRef | null>
         locationSubscription.current = null;
       }
     };
-  }, [
-    checkUnsavedTrackLog,
-    confirmLocationPermission,
-    ensureBackgroundGeolocation,
-    ensureHeadingSubscription,
-    stopTracking,
-    trackingState,
-    moveCurrentPosition,
-  ]);
+    // 初期化はマウント時に1回だけ実行する（本体はinitializedRefで多重実行を防いでいる）。
+    // 依存配列に状態やコールバックを含めると、依存変化時の再実行でクリーンアップが
+    // heading/onLocation購読を破棄し（本体は早期returnするため）再購読されず、
+    // 追跡中に位置・方位の更新が止まる不具合の原因になる。クリーンアップはアンマウント時のみ実行する。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const subscription = RNAppState.addEventListener('change', async (nextAppState) => {

--- a/src/utils/Coords.ts
+++ b/src/utils/Coords.ts
@@ -963,33 +963,34 @@ export const cleanupLine = (line: LocationType[]): LocationType[] => {
   const lineString = turf.lineString(smoothedLine.map((point) => [point.longitude, point.latitude]));
 
   const simplifiedLine = turf.simplify(lineString, { tolerance: 0.000001, highQuality: true });
-  
-  // 簡略化された座標に対して、最も近い元の点のtimestampとその他のプロパティを復元
+
+  // 簡略化後の座標に元の点のプロパティ(timestamp等)を復元する。
+  // turf.simplify(Douglas-Peucker)は元の座標値をそのまま部分集合として返すため、
+  // 座標をキーにしたMapでO(N)に対応付けできる（旧実装の最近傍線形探索O(N²)を回避）。
+  // 同一座標が複数ある場合は最初の点を優先（旧実装の strict `<` 比較=最初に見つかった最小と一致）。
+  const coordKey = (lon: number, lat: number) => `${lon.toFixed(8)}|${lat.toFixed(8)}`;
+  const pointByCoord = new Map<string, LocationType>();
+  for (const point of smoothedLine) {
+    const k = coordKey(point.longitude, point.latitude);
+    if (!pointByCoord.has(k)) pointByCoord.set(k, point);
+  }
+
+  let lastMatched = smoothedLine[0];
   const newTrack = simplifiedLine.geometry.coordinates.map((coord) => {
-    // 最も近い元の点を見つける
-    let minDistance = Infinity;
-    let closestPoint = smoothedLine[0];
-    
-    for (const point of smoothedLine) {
-      const distance = Math.sqrt(
-        Math.pow(coord[0] - point.longitude, 2) + 
-        Math.pow(coord[1] - point.latitude, 2)
-      );
-      if (distance < minDistance) {
-        minDistance = distance;
-        closestPoint = point;
-      }
-    }
-    
+    // 簡略化座標は元の座標そのものなので完全一致でヒットする。
+    // 万一ヒットしない場合は直前に一致した点へフォールバック。
+    const matched = pointByCoord.get(coordKey(coord[0], coord[1])) ?? lastMatched;
+    lastMatched = matched;
+
     // 元の点のプロパティを含めて返す
     return {
       longitude: coord[0],
       latitude: coord[1],
-      timestamp: closestPoint.timestamp, // timestampを復元
-      ...(closestPoint.altitude !== undefined && { altitude: closestPoint.altitude }),
-      ...(closestPoint.accuracy !== undefined && { accuracy: closestPoint.accuracy }),
-      ...(closestPoint.speed !== undefined && { speed: closestPoint.speed }),
-      ...(closestPoint.heading !== undefined && { heading: closestPoint.heading }),
+      timestamp: matched.timestamp, // timestampを復元
+      ...(matched.altitude !== undefined && { altitude: matched.altitude }),
+      ...(matched.accuracy !== undefined && { accuracy: matched.accuracy }),
+      ...(matched.speed !== undefined && { speed: matched.speed }),
+      ...(matched.heading !== undefined && { heading: matched.heading }),
     };
   });
   return newTrack;

--- a/src/utils/Location.ts
+++ b/src/utils/Location.ts
@@ -14,8 +14,90 @@ export interface TrackChunkMetadata {
   totalPoints: number;
   lastChunkIndex: number;
   lastTimeStamp: number;
+  // 累積総距離(km)。記録開始からの合計（チャンクを跨いで増分加算する）。
   currentDistance: number;
 }
+
+// ---------------------------------------------------------------------------
+// 書き込みスルー型メモリ内キャッシュ
+// GPS 1点ごとのMMKV往復(getString/JSON.parse)とturf距離計算を排除するため、
+// 現在のチャンクとメタデータをメモリに保持する。MMKVへの書き込みはスロットルし、
+// rollover時とflush時、フォアグラウンド/停止/保存時には必ず書き込む。
+//
+// 重要: headlessタスク(アプリkill時)はメインとは別のJSコンテキストで動くため、
+// このキャッシュは共有されない。MMKVが唯一のコンテキスト間共有・永続の真実の源。
+// headless側ではタスク先頭でresetTrackLogCache()・末尾でflushTrackLog()を呼び、
+// 毎回MMKVから読み・書きすることでキャッシュのドリフトを避ける。
+// ---------------------------------------------------------------------------
+const WRITE_EVERY_N = 10; // 未完成チャンクの書き込みは最大Nポイントに1回
+const WRITE_INTERVAL_MS = 3000; // または数秒ごと
+
+interface TrackLogCache {
+  currentChunk: LocationType[]; // index>0 のときはつなぎ目を element0 に含む（getCurrentChunkと同形）
+  metadata: TrackChunkMetadata;
+  lastAppendedPoint: LocationType | null; // 増分距離計算用に最後に追加した点
+}
+
+let cache: TrackLogCache | null = null;
+let pendingWrites = 0;
+let lastFlushTs = 0;
+
+// turf非依存の軽量な大圏距離(km)。turf.length(getLineLength)と同じ地球半径6371kmを使用し、
+// ライブ表示の累積距離が保存時の最終距離とほぼ一致するようにする。
+const haversineKm = (a: LocationType, b: LocationType): number => {
+  const R = 6371;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLon = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLon = Math.sin(dLon / 2);
+  const h = sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLon * sinDLon;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+};
+
+// キャッシュを破棄する。次回アクセス時にMMKVから再ハイドレートされる。
+export const resetTrackLogCache = (): void => {
+  cache = null;
+  pendingWrites = 0;
+  lastFlushTs = 0;
+};
+
+// キャッシュが無ければMMKVから読み込んで構築する。
+const ensureCache = (): TrackLogCache => {
+  if (cache) return cache;
+  const metadata = getTrackMetadata();
+  const { chunk } = getCurrentChunk();
+  cache = {
+    currentChunk: chunk,
+    metadata,
+    lastAppendedPoint: chunk.length > 0 ? chunk[chunk.length - 1] : null,
+  };
+  return cache;
+};
+
+// キャッシュの現在チャンク+メタデータをMMKVへ書き込む。
+const persistCache = (): void => {
+  if (!cache) return;
+  const { currentChunk, metadata } = cache;
+  const currentChunkIndex = metadata.lastChunkIndex;
+  saveTrackMetadata(metadata);
+  if (currentChunk.length > 0) {
+    // つなぎ目を除いて保存（2番目以降のチャンクは最初の点を除外）
+    const chunkToSave = currentChunkIndex > 0 && currentChunk.length > 1 ? currentChunk.slice(1) : currentChunk;
+    saveTrackChunk(currentChunkIndex, chunkToSave);
+  } else {
+    saveTrackChunk(currentChunkIndex, []);
+  }
+  pendingWrites = 0;
+  lastFlushTs = Date.now();
+};
+
+// 未書き込みのキャッシュ内容を強制的にMMKVへ書き込む（バックグラウンド移行/停止/保存前に呼ぶ）。
+export const flushTrackLog = (): void => {
+  persistCache();
+};
 
 export const clearStoredLocations = (): void => {
   // すべてのチャンクデータをクリア
@@ -73,26 +155,30 @@ export const toLocationObject = (location: any): LocationObjectInput => {
   };
 };
 
-export const checkAndStoreLocations = (locations: LocationObjectInput[]): void => {
+export const checkAndStoreLocations = (
+  locations: LocationObjectInput[]
+): { metadata: TrackChunkMetadata; chunk: LocationType[] } | null => {
   // トラッキングがOFFの場合は軌跡を保存しない（GPSのみONでの記録を防止）
-  if (trackLogMMKV.getTrackingState() !== 'on') return;
+  if (trackLogMMKV.getTrackingState() !== 'on') return null;
 
-  // メタデータから最終タイムスタンプを取得
-  const metadata = getTrackMetadata();
+  // キャッシュ（無ければMMKVからハイドレート）から最終タイムスタンプを取得
+  const c = ensureCache();
 
   // 位置情報の検証とフィルタリング
-  const checkedLocations = checkLocations(metadata.lastTimeStamp, locations);
+  const checkedLocations = checkLocations(c.metadata.lastTimeStamp, locations);
 
-  if (checkedLocations.length > 0) {
-    // チャンクシステムに追加（これが唯一のデータ保存）
-    addLocationsToChunks(checkedLocations);
+  if (checkedLocations.length === 0) return null;
 
-    // 現在地を別途保存（互換性のため）
-    const displayData = getDisplayBuffer();
-    if (displayData.length > 0) {
-      trackLogMMKV.setCurrentLocation(displayData[displayData.length - 1]);
-    }
+  // チャンクシステムに追加（これが唯一のデータ保存）
+  const result = addLocationsToChunks(checkedLocations);
+
+  // 現在地を別途保存（互換性のため）
+  const lastPoint = result.chunk[result.chunk.length - 1];
+  if (lastPoint) {
+    trackLogMMKV.setCurrentLocation(lastPoint);
   }
+
+  return result;
 };
 
 // toLocationType関数を先に定義（checkLocationsで使用するため）
@@ -167,17 +253,29 @@ const getCurrentChunk = (): { chunk: LocationType[]; index: number } => {
 // LocationTypeをそのまま使用する
 
 // チャンクシステムに位置情報を追加
-export const addLocationsToChunks = (locations: LocationType[]): void => {
-  const metadata = getTrackMetadata();
-
-  // MMKVから現在のチャンク状態を取得（つなぎ目付き）
-  let { chunk: currentChunk, index: currentChunkIndex } = getCurrentChunk();
+// メモリ内キャッシュを更新し、戻り値で最新のmetadata/現在チャンクを返す。
+// MMKVへの書き込みは rollover時は必ず、未完成チャンクはスロットルして行う。
+export const addLocationsToChunks = (
+  locations: LocationType[]
+): { metadata: TrackChunkMetadata; chunk: LocationType[] } => {
+  const c = ensureCache();
+  const metadata = c.metadata;
+  let currentChunk = c.currentChunk;
+  let currentChunkIndex = metadata.lastChunkIndex;
+  let lastAppended = c.lastAppendedPoint;
 
   let totalPointsAdded = 0;
+  let distanceAdded = 0;
+  let rolledOver = false;
 
   for (const location of locations) {
+    // 増分距離（最後に追加した点からの大圏距離を加算）。チャンクを跨いでも連続して加算する。
+    if (lastAppended) {
+      distanceAdded += haversineKm(lastAppended, location);
+    }
+    lastAppended = location;
+
     // 現在のチャンクに追加（保存と表示を兼ねる）
-    // LocationTypeをそのまま使用
     currentChunk.push(location);
     totalPointsAdded++;
 
@@ -192,7 +290,7 @@ export const addLocationsToChunks = (locations: LocationType[]): void => {
       // つなぎ目を除いてチャンクを保存（2番目以降のチャンクは最初の点を除外）
       const chunkToSave = currentChunkIndex > 0 ? currentChunk.slice(1) : currentChunk;
 
-      // チャンクを保存（cleanupはトラック保存時に実行）
+      // 完成チャンクは即保存（cleanupはトラック保存時に実行）
       saveTrackChunk(currentChunkIndex, chunkToSave);
 
       // メタデータを更新
@@ -202,11 +300,9 @@ export const addLocationsToChunks = (locations: LocationType[]): void => {
 
       // 新しいチャンクを開始（前のチャンクの最後の点を含める）
       currentChunk = [lastPointOfCurrentChunk];
+      rolledOver = true;
     }
   }
-
-  // 距離を計算（現在のチャンクの距離）
-  const currentDistance = currentChunk.length >= 2 ? getLineLength(currentChunk) : 0;
 
   // メタデータを更新
   metadata.totalPoints += totalPointsAdded;
@@ -214,32 +310,42 @@ export const addLocationsToChunks = (locations: LocationType[]): void => {
   if (locations.length > 0) {
     metadata.lastTimeStamp = locations[locations.length - 1]?.timestamp || Date.now();
   }
-  metadata.currentDistance = currentDistance; // 距離を保存
-  metadata.lastChunkIndex = currentChunkIndex; // 現在のチャンクインデックスも保存
-  saveTrackMetadata(metadata);
+  metadata.currentDistance += distanceAdded; // 累積総距離に加算
+  metadata.lastChunkIndex = currentChunkIndex;
 
-  // 現在のチャンクを常に保存（表示用データとして使用される）
-  // 注意: 最後のチャンクはまだ完成していないのでcleanupしない
-  if (currentChunk.length > 0) {
-    // つなぎ目を除いて保存（2番目以降のチャンクは最初の点を除外）
-    const chunkToSave = currentChunkIndex > 0 && currentChunk.length > 1 ? currentChunk.slice(1) : currentChunk;
-    // 未完成のチャンクはcleanupしない（トラック保存時に処理）
-    saveTrackChunk(currentChunkIndex, chunkToSave);
-  } else {
-    // 空のチャンクも保存（新しいチャンクが作成されたが、まだポイントがない場合）
-    saveTrackChunk(currentChunkIndex, []);
+  // キャッシュを更新
+  c.currentChunk = currentChunk;
+  c.lastAppendedPoint = lastAppended;
+
+  // 書き込み: rollover時は必ず（metadata.lastChunkIndexとMMKV上のチャンクの整合のため）。
+  // それ以外はスロットル（Nポイントごと、または数秒ごと）。
+  pendingWrites += totalPointsAdded;
+  const now = Date.now();
+  if (rolledOver || pendingWrites >= WRITE_EVERY_N || now - lastFlushTs >= WRITE_INTERVAL_MS) {
+    persistCache();
   }
+
+  return { metadata, chunk: currentChunk };
 };
 
 // 表示用バッファを取得（現在のチャンクを取得）
 // 注意: パフォーマンスのため配列の参照を直接返す（コピーしない）
+// キャッシュがあればメモリから返す（MMKVのparseを回避）。無ければMMKVから読む。
 export const getDisplayBuffer = (): LocationType[] => {
+  if (cache) return cache.currentChunk;
   const { chunk } = getCurrentChunk();
   return chunk; // 配列のコピーを作らず直接返す
 };
 
 // 現在のチャンク情報を取得（デバッグ用）
 export const getCurrentChunkInfo = () => {
+  if (cache) {
+    return {
+      currentChunkIndex: cache.metadata.lastChunkIndex,
+      currentChunkSize: cache.currentChunk.length,
+      displayBufferSize: cache.currentChunk.length,
+    };
+  }
   const { chunk, index } = getCurrentChunk();
   return {
     currentChunkIndex: index,
@@ -317,6 +423,8 @@ export const saveTrackMetadata = (metadata: TrackChunkMetadata): void => {
 
 // 全チャンクを結合して取得（エクスポート用）
 export const getAllTrackPoints = (): LocationType[] => {
+  // メモリ内の未書き込みポイントもMMKVへ反映してから読み出す（保存の取りこぼし防止）
+  flushTrackLog();
   const metadata = getTrackMetadata();
   const allPoints: LocationType[] = [];
 
@@ -336,8 +444,10 @@ export const getAllTrackPoints = (): LocationType[] => {
 // チャンクデータをクリア
 export const clearAllChunks = (): void => {
   const metadata = getTrackMetadata();
+  // 未flushのキャッシュがMMKVより進んでいる可能性があるため、両者の大きい方まで削除する
+  const maxChunkIndex = Math.max(metadata.lastChunkIndex, cache?.metadata.lastChunkIndex ?? 0);
 
-  for (let i = 0; i <= metadata.lastChunkIndex; i++) {
+  for (let i = 0; i <= maxChunkIndex; i++) {
     trackLogMMKV.removeChunk(`track_chunk_${i}`);
   }
 
@@ -351,6 +461,9 @@ export const clearAllChunks = (): void => {
 
   // MMKVに空のチャンクを保存して初期化
   saveTrackChunk(0, []);
+
+  // メモリ内キャッシュも破棄（次回アクセス時にクリア済みのMMKVから再構築）
+  resetTrackLogCache();
 };
 
 /**

--- a/src/utils/__tests__/Coords.test.ts
+++ b/src/utils/__tests__/Coords.test.ts
@@ -1,4 +1,5 @@
-import { decimal2dms, dms2decimal, toLatLonDMS, pointsToSvg, calcCentroid, isNearWithPlot } from '../Coords';
+import { decimal2dms, dms2decimal, toLatLonDMS, pointsToSvg, calcCentroid, isNearWithPlot, cleanupLine } from '../Coords';
+import { LocationType } from '../../types';
 
 describe('decimal2dms', () => {
   it('return dms value from decimal', () => {
@@ -72,5 +73,57 @@ describe('isNearWithPlot', () => {
     expect(result1).toBe(true);
     expect(result2).toBe(true);
     expect(result3).toBe(false);
+  });
+});
+
+describe('cleanupLine', () => {
+  // 蛇行する軌跡を生成（turf.simplifyが多数の頂点を保持するよう正弦波状にする）
+  const makeWigglyLine = (n: number): LocationType[] =>
+    Array.from({ length: n }, (_, i) => ({
+      latitude: 35 + 0.001 * Math.sin(i / 5),
+      longitude: 135 + i * 0.0001,
+      timestamp: 1_600_000_000_000 + i * 1000,
+      accuracy: 10,
+      altitude: 100 + i,
+      speed: 1,
+      heading: 90,
+    }));
+
+  it('returns input unchanged when fewer than 10 points', () => {
+    const line = makeWigglyLine(5);
+    expect(cleanupLine(line)).toBe(line);
+  });
+
+  it('restores timestamp/properties from original points and preserves order', () => {
+    const line = makeWigglyLine(2000);
+    const inputTimestamps = new Set(line.map((p) => p.timestamp));
+
+    const result = cleanupLine(line);
+
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    expect(result.length).toBeLessThanOrEqual(line.length);
+
+    // 全ての出力点は元の点のtimestampを持つ（最近傍ではなく座標一致で復元できている）
+    for (const point of result) {
+      expect(inputTimestamps.has(point.timestamp)).toBe(true);
+      expect(point.altitude).toBeDefined();
+      expect(point.accuracy).toBeDefined();
+    }
+
+    // timestampは昇順（順序が保たれている）
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i].timestamp!).toBeGreaterThanOrEqual(result[i - 1].timestamp!);
+    }
+  });
+
+  it('handles large tracks without O(N^2) blowup (regression guard)', () => {
+    const line = makeWigglyLine(20000);
+    const start = Date.now();
+    const result = cleanupLine(line);
+    const elapsed = Date.now() - start;
+
+    expect(result.length).toBeGreaterThan(2);
+    // 旧実装(O(N^2))では数秒〜かかっていた。O(N)化により十分高速に完了する。
+    expect(elapsed).toBeLessThan(5000);
   });
 });

--- a/src/utils/__tests__/Location.test.ts
+++ b/src/utils/__tests__/Location.test.ts
@@ -6,7 +6,17 @@ import {
   checkLocations,
   isLowAccuracy,
   splitTrackByAccuracy,
+  addLocationsToChunks,
+  checkAndStoreLocations,
+  getDisplayBuffer,
+  getCurrentChunkInfo,
+  getTrackChunk,
+  clearAllChunks,
+  resetTrackLogCache,
+  flushTrackLog,
+  CHUNK_SIZE,
 } from '../Location';
+import { trackLogMMKV } from '../mmkvStorage';
 import { LocationType } from '../../types';
 
 // モジュールのモック
@@ -50,6 +60,10 @@ jest.mock('../mmkvStorage', () => {
         mockStorage.metadata = metadata;
       }),
       getMetadata: jest.fn(() => mockStorage.metadata || null),
+      setTrackingState: jest.fn((state) => {
+        mockStorage.trackingState = state;
+      }),
+      getTrackingState: jest.fn(() => mockStorage.trackingState ?? 'on'),
     },
     storage: {
       set: jest.fn(),
@@ -382,5 +396,131 @@ describe('splitTrackByAccuracy', () => {
     expect(result).toHaveLength(1);
     expect(result[0].isLowAccuracy).toBe(false);
     expect(result[0].coordinates).toHaveLength(3);
+  });
+});
+
+describe('addLocationsToChunks (cache, incremental distance, rollover)', () => {
+  const baseTime = 1_600_000_000_000;
+  // 35°付近で経度を一定刻みに増やした点列を生成
+  const makePoints = (n: number, startIndex = 0): LocationType[] =>
+    Array.from({ length: n }, (_, k) => {
+      const i = startIndex + k;
+      return { latitude: 35, longitude: 135 + i * 0.0001, timestamp: baseTime + i * 1000, accuracy: 10 };
+    });
+
+  beforeEach(() => {
+    clearAllChunks(); // メタデータ・チャンク・メモリ内キャッシュをリセット
+  });
+
+  it('returns updated metadata and current chunk', () => {
+    const result = addLocationsToChunks(makePoints(3));
+    expect(result.metadata.totalPoints).toBe(3);
+    expect(result.metadata.lastChunkIndex).toBe(0);
+    expect(result.chunk).toHaveLength(3);
+  });
+
+  it('accumulates distance across chunk boundaries without resetting (Cause C regression)', () => {
+    const distances: number[] = [];
+    const total = CHUNK_SIZE * 2 + 100; // CHUNK_SIZE(500)を2回跨ぐ
+    for (let i = 0; i < total; i++) {
+      const result = addLocationsToChunks(makePoints(1, i));
+      distances.push(result.metadata.currentDistance);
+    }
+
+    // 各点で正の距離が加算され単調増加する
+    for (let i = 1; i < distances.length; i++) {
+      expect(distances[i]).toBeGreaterThan(distances[i - 1]);
+    }
+
+    // チャンク境界(500, 1000)でリセットされない
+    expect(distances[CHUNK_SIZE]).toBeGreaterThan(distances[CHUNK_SIZE - 1]);
+    expect(distances[CHUNK_SIZE * 2]).toBeGreaterThan(distances[CHUNK_SIZE * 2 - 1]);
+
+    // 累積総距離は最後のチャンクのみの距離よりはるかに大きい（旧バグでは最後のチャンク分しか出なかった）
+    const lastChunkSpan = distances[total - 1] - distances[CHUNK_SIZE * 2 - 1];
+    expect(distances[total - 1]).toBeGreaterThan(lastChunkSpan * 5);
+  });
+
+  it('keeps the seam point at the head of the new chunk after rollover', () => {
+    const points = makePoints(CHUNK_SIZE + 1);
+    addLocationsToChunks(points);
+
+    // チャンク0は500点が保存される
+    expect(getTrackChunk(0)).toHaveLength(CHUNK_SIZE);
+    // 現在チャンクのインデックスは1
+    expect(getCurrentChunkInfo().currentChunkIndex).toBe(1);
+    // 表示バッファ先頭はつなぎ目（500番目=index CHUNK_SIZE-1 の点）
+    const buffer = getDisplayBuffer();
+    expect(buffer[0].timestamp).toBe(points[CHUNK_SIZE - 1].timestamp);
+    // 末尾は501番目（index CHUNK_SIZE）の点
+    expect(buffer[buffer.length - 1].timestamp).toBe(points[CHUNK_SIZE].timestamp);
+  });
+
+  it('throttles writes of the unfinished chunk and flushTrackLog forces a write', () => {
+    (trackLogMMKV.setChunk as jest.Mock).mockClear();
+    const n = 50; // CHUNK_SIZE未満（rolloverなし）
+    for (let i = 0; i < n; i++) {
+      addLocationsToChunks(makePoints(1, i));
+    }
+    // 未完成チャンク(track_chunk_0)への書き込みは点数より大幅に少ない（スロットル）
+    const chunk0Writes = (trackLogMMKV.setChunk as jest.Mock).mock.calls.filter(
+      (c: any[]) => c[0] === 'track_chunk_0'
+    ).length;
+    expect(chunk0Writes).toBeLessThan(n);
+    expect(chunk0Writes).toBeLessThanOrEqual(10);
+
+    // flushTrackLogで強制書き込み
+    (trackLogMMKV.setChunk as jest.Mock).mockClear();
+    flushTrackLog();
+    expect((trackLogMMKV.setChunk as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+  });
+});
+
+describe('checkAndStoreLocations (tracking state + return value)', () => {
+  const baseTime = 1_600_000_000_000;
+  const makeInput = (n: number, startIndex = 0): LocationObjectInput[] =>
+    Array.from({ length: n }, (_, k) => {
+      const i = startIndex + k;
+      return { coords: { latitude: 35, longitude: 135 + i * 0.0001, accuracy: 10 }, timestamp: baseTime + i * 1000 };
+    });
+
+  beforeEach(() => {
+    clearAllChunks();
+    trackLogMMKV.setTrackingState('on');
+  });
+
+  it('returns null when tracking is off', () => {
+    trackLogMMKV.setTrackingState('off');
+    expect(checkAndStoreLocations(makeInput(1))).toBeNull();
+  });
+
+  it('stores points and returns metadata/chunk when tracking is on', () => {
+    const result = checkAndStoreLocations(makeInput(3));
+    expect(result).not.toBeNull();
+    expect(result!.metadata.totalPoints).toBe(3);
+    expect(result!.chunk).toHaveLength(3);
+  });
+});
+
+describe('resetTrackLogCache', () => {
+  const baseTime = 1_600_000_000_000;
+  const makePoints = (n: number, startIndex = 0): LocationType[] =>
+    Array.from({ length: n }, (_, k) => {
+      const i = startIndex + k;
+      return { latitude: 35, longitude: 135 + i * 0.0001, timestamp: baseTime + i * 1000, accuracy: 10 };
+    });
+
+  beforeEach(() => {
+    clearAllChunks();
+  });
+
+  it('re-reads from MMKV after reset (headless writes MMKV in a separate context)', () => {
+    addLocationsToChunks(makePoints(3));
+    flushTrackLog(); // MMKVへ確定
+    expect(getCurrentChunkInfo().currentChunkSize).toBe(3);
+
+    // 別コンテキスト相当: キャッシュを破棄 → 次回アクセスはMMKVから再構築
+    resetTrackLogCache();
+    expect(getDisplayBuffer()).toHaveLength(3);
   });
 });


### PR DESCRIPTION
## 概要
GPS軌跡記録を「長時間記録しても電池消費が少なく、専用GPSロガーと遜色なく使える」状態にするための不具合修正とパフォーマンス改善。

## 変更内容
- **購読破棄バグ修正**: 初期化effectの依存配列起因でonLocation/heading購読が破棄され、追跡中に位置・方位の更新が止まる不具合を修正（マウント時1回実行に変更）
- **電池消費改善**: バックグラウンド中のReact state更新・animateCameraをスキップ（MMKV保存・接近通知は継続、復帰時に表示復元）。旧実装はバックグラウンド中こそ毎フィックスでカメラ移動を実行していた
- **記録の連続性**: 静止検出を明示無効化（disableStopDetection + pausesLocationUpdatesAutomatically:false）し、iOSで静止5分後に記録が止まるリスクを排除。ヘッドレスタスクにboot/terminate処理を追加しAndroid再起動後の記録再開を保証
- **長時間記録の最適化**: MMKV書き込みのメモリキャッシュ化・スロットル、距離計算の軽量化、cleanupLineのO(N)化、方位更新の間引き（200ms/1°）
- **その他修正**: トラッキング停止後のheading購読リーク、コンパスOFF後の方位凍結、コンパス角度計算の0/360ラップ未対応・trueHeading無効値ガード

## テスト
- [x] 型チェック通過
- [x] リント通過
- [x] テスト通過（61スイート / 564テスト、回帰テスト追加）
- [ ] iOS動作確認（15分以上静止後の軌跡連続性・電池比較は実機検証待ち）
- [ ] Android動作確認（再起動後の記録継続・batterystats比較は実機検証待ち）
- [x] Web動作確認（トラッキングはWeb無効のため影響なし、全テストで確認）

## 関連Issue
なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)